### PR TITLE
fix(security): Replace MD5 with SHA-256 for deterministic UUID generation

### DIFF
--- a/src/n8n_fabric/storage/qdrant.py
+++ b/src/n8n_fabric/storage/qdrant.py
@@ -13,8 +13,8 @@ from sentence_transformers import SentenceTransformer
 
 def string_to_uuid(s: str) -> str:
     """Convert a string to a deterministic UUID."""
-    # Create a deterministic UUID from the string using MD5 hash
-    hash_bytes = hashlib.md5(s.encode()).digest()
+    # Create a deterministic UUID from the string using SHA-256 (truncated to 16 bytes)
+    hash_bytes = hashlib.sha256(s.encode()).digest()[:16]
     return str(UUID(bytes=hash_bytes))
 
 


### PR DESCRIPTION
## Summary

Resolves CodeQL code scanning alert: **Weak hash (MD5) for sensitive data** in `src/n8n_fabric/storage/qdrant.py`.

### Changes

- Replace `hashlib.md5` with `hashlib.sha256` (truncated to 16 bytes) in `string_to_uuid()`
- Update inline comment to reflect the new algorithm

### Impact

**Breaking change for existing indexed data.** The deterministic UUIDs generated by `string_to_uuid()` will differ from those previously generated with MD5. Any workflows already indexed in Qdrant will need to be **re-indexed** after this change, as lookups by workflow ID will produce different point IDs.

### Why SHA-256?

- SHA-256 is not considered cryptographically weak for this use case
- Truncating to 16 bytes preserves UUID compatibility
- The function only needs determinism, not collision resistance, but using a strong hash eliminates the CodeQL alert and follows security best practices

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Use SHA-256 instead of MD5 to generate deterministic UUIDs in Qdrant storage, fixing the CodeQL weak-hash alert. This changes UUIDs, so existing indexed workflows need re-indexing.

- **Bug Fixes**
  - Replace hashlib.md5 with hashlib.sha256 (truncated to 16 bytes) in string_to_uuid().

- **Migration**
  - Re-index all workflows in Qdrant to regenerate point IDs.
  - Verify lookups by workflow ID after re-indexing.

<sup>Written for commit 59403f95fd465a30b4d4cf38b31e85eef7568de1. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

